### PR TITLE
Fix TypeScript linting errors: remove unused imports and variables

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -9,15 +9,11 @@ import {
   CardContent,
   Avatar,
   useTheme,
-  useMediaQuery,
   Chip,
   Stack,
-  IconButton,
   Fade,
   Slide,
   Zoom,
-  Paper,
-  Divider,
 } from '@mui/material';
 import {
   People,
@@ -27,29 +23,18 @@ import {
   TrendingUp,
   Security,
   Support,
-  School,
   ArrowForward,
   PlayArrow,
-  CheckCircle,
   Mosque,
   DirectionsBus,
   HomeWork,
-  Phone,
-  Email,
   Facebook,
-  Twitter,
-  Instagram,
-  LinkedIn,
-  MenuBook,
-  Group,
-  Speed,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import mcanLogo from '../assets/mcanlogo.jpg';
 
 const HomePage: React.FC = () => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const navigate = useNavigate();
   const [isVisible, setIsVisible] = useState(false);
 

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -24,7 +24,6 @@ import {
   Person,
   Phone,
   LocationOn,
-  Work,
   PersonAdd,
 } from '@mui/icons-material';
 import { useForm } from 'react-hook-form';


### PR DESCRIPTION
- Remove unused imports: IconButton, Paper, Divider, School, CheckCircle, Phone, Email, Twitter, Instagram, LinkedIn, MenuBook, Group, Speed from HomePage.tsx
- Remove unused variable: isMobile from HomePage.tsx
- Remove unused import: Work from RegisterPage.tsx
- These fixes resolve Netlify build failures due to warnings being treated as errors in CI environment